### PR TITLE
chore: align Lombok, JaCoCo, Mockito, and Byte Buddy for JDK 25

### DIFF
--- a/booking-service/pom.xml
+++ b/booking-service/pom.xml
@@ -199,7 +199,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>${lombok.version}</version>
                         </path>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/car-service/pom.xml
+++ b/car-service/pom.xml
@@ -199,7 +199,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>${lombok.version}</version>
                         </path>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/dispute-service/pom.xml
+++ b/dispute-service/pom.xml
@@ -29,6 +29,14 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>net.logstash.logback</groupId>
@@ -137,7 +145,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>${lombok.version}</version>
                         </path>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -112,7 +112,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>${lombok.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,9 @@
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
         <logstash.encoder.version>7.4</logstash.encoder.version>
         <jjwt.version>0.11.5</jjwt.version>
+        <lombok.version>1.18.42</lombok.version>
+        <byte-buddy.version>1.17.7</byte-buddy.version>
+        <mockito.version>5.23.0</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -81,23 +84,25 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version> <executions>
+                <version>0.8.14</version>
+                <executions>
                     <execution>
                         <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
-                        </execution>
+                    </execution>
                     <execution>
                         <id>report</id>
-                        <phase>verify</phase> <goals>
+                        <phase>verify</phase>
+                        <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                             <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
                         </configuration>
                     </execution>
-                    </executions>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -113,7 +118,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>${lombok.version}</version>
                         </path>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -170,7 +170,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>${lombok.version}</version>
                         </path>
                         <path>
                             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
- Centralize lombok version for annotation processors across modules.
- JaCoCo 0.8.14 for current bytecode versions.
- Override Mockito and Byte Buddy versions for test tooling.
- Add WebFlux and Spring Cloud LoadBalancer to dispute-service.