### PR TITLE
feat: protect user-service internal APIs with shared secret header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,7 @@ POSTGRES_DB=dynamic_car_sharing_db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
 JWT_SECRET=
+# Same value must be set on user-service, booking-service, and car-service for service-to-service calls to /api/v1/internal/users/** on user-service.
+USER_SERVICE_INTERNAL_API_KEY=
 GF_SECURITY_ADMIN_USER=admin
 GF_SECURITY_ADMIN_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ JAR_PATH=services/car-service/target/car-service-1.0-SNAPSHOT.jar ./scripts/jvm/
 
 This is the **simplest way** to run the whole platform: all microservices, databases, Kafka, Redis, Eureka, observability, etc.
 
-Create a local env file from the template and set secrets (database password, `JWT_SECRET`, Grafana admin password):
+Create a local env file from the template and set secrets (database password, `JWT_SECRET`, `USER_SERVICE_INTERNAL_API_KEY`, Grafana admin password):
 
 ```bash
 cp .env.example .env
@@ -235,6 +235,8 @@ docker compose up --build
 ```
 
 Wait until health checks pass; then use the [Service Endpoints](#service-endpoints) (e.g. API Gateway on port **8085**).
+
+**Internal user-service APIs** — `GET /api/v1/internal/users/**` is intended for trusted service-to-service calls only. The caller must send header **`X-Internal-Api-Key`** with the same secret that **user-service** validates. Set **`USER_SERVICE_INTERNAL_API_KEY`** to one shared value on **user-service**, **booking-service**, and **car-service** (Docker Compose wires it from `.env`; see `.env.example`). Do not commit the real secret.
 
 ### Run microservices separately (optional, for local development)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,7 @@ services:
     environment:
       - EUREKA_INSTANCE_HOSTNAME=user-service-1
       - MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED=true
+      - USER_SERVICE_INTERNAL_API_KEY=${USER_SERVICE_INTERNAL_API_KEY:-dev-internal-api-key-change-me}
     depends_on:
       db:
         condition: service_healthy
@@ -150,6 +151,7 @@ services:
     environment:
       - EUREKA_INSTANCE_HOSTNAME=user-service-2
       - MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED=true
+      - USER_SERVICE_INTERNAL_API_KEY=${USER_SERVICE_INTERNAL_API_KEY:-dev-internal-api-key-change-me}
     depends_on:
       db:
         condition: service_healthy
@@ -204,6 +206,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - JWT_SECRET=${JWT_SECRET}
+      - USER_SERVICE_INTERNAL_API_KEY=${USER_SERVICE_INTERNAL_API_KEY:-dev-internal-api-key-change-me}
     networks:
       - microservices-network
     healthcheck:
@@ -226,6 +229,7 @@ services:
       - MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED=true
       - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - APPLICATION_MESSAGING_KAFKA_ENABLED=true
+      - USER_SERVICE_INTERNAL_API_KEY=${USER_SERVICE_INTERNAL_API_KEY:-dev-internal-api-key-change-me}
     depends_on:
       db:
         condition: service_healthy

--- a/services/booking-service/src/main/java/com/dynamiccarsharing/booking/integration/client/WebClientUserIntegrationClient.java
+++ b/services/booking-service/src/main/java/com/dynamiccarsharing/booking/integration/client/WebClientUserIntegrationClient.java
@@ -7,6 +7,7 @@ import com.dynamiccarsharing.util.exception.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -17,6 +18,9 @@ import java.time.Duration;
 @Component
 @Slf4j
 public class WebClientUserIntegrationClient implements UserIntegrationClient {
+
+    private static final String INTERNAL_USER_BY_ID_PATH = "/api/v1/internal/users/{id}";
+    private static final String INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key";
 
     private final WebClient userWebClient;
     private final IntegrationClientProperties properties;
@@ -30,7 +34,12 @@ public class WebClientUserIntegrationClient implements UserIntegrationClient {
     public void assertUserExists(Long userId) {
         try {
             UserDto user = userWebClient.get()
-                    .uri("/api/v1/users/{id}", userId)
+                    .uri(INTERNAL_USER_BY_ID_PATH, userId)
+                    .headers(h -> {
+                        if (StringUtils.hasText(properties.getInternalApiKey())) {
+                            h.set(INTERNAL_API_KEY_HEADER, properties.getInternalApiKey());
+                        }
+                    })
                     .retrieve()
                     .onStatus(HttpStatusCode::is5xxServerError, response ->
                             response.createException().map(ex -> new ServiceException("User service is unavailable", ex))

--- a/services/booking-service/src/main/java/com/dynamiccarsharing/booking/integration/config/IntegrationClientProperties.java
+++ b/services/booking-service/src/main/java/com/dynamiccarsharing/booking/integration/config/IntegrationClientProperties.java
@@ -11,4 +11,8 @@ public class IntegrationClientProperties {
     private long timeoutSeconds = 3;
     private long retryMaxAttempts = 2;
     private long retryBackoffMillis = 200;
+    /**
+     * Shared secret for {@code X-Internal-Api-Key} when calling user-service internal APIs.
+     */
+    private String internalApiKey = "";
 }

--- a/services/booking-service/src/main/resources/application.yml
+++ b/services/booking-service/src/main/resources/application.yml
@@ -89,6 +89,7 @@ application:
       timeout-seconds: 3
       retry-max-attempts: 2
       retry-backoff-millis: 200
+      internal-api-key: ${USER_SERVICE_INTERNAL_API_KEY:}
   reminders:
     enabled: false
     hours-before-start: 24

--- a/services/booking-service/src/test/java/com/dynamiccarsharing/booking/service/BookingServiceIntegrationTest.java
+++ b/services/booking-service/src/test/java/com/dynamiccarsharing/booking/service/BookingServiceIntegrationTest.java
@@ -73,6 +73,7 @@ class BookingServiceIntegrationTest {
             ResponseSpec responseSpec = mock(ResponseSpec.class);
             when(wc.get()).thenReturn(uriSpec);
             when(uriSpec.uri(anyString(), anyLong())).thenReturn(uriSpec);
+            when(uriSpec.headers(any())).thenReturn(uriSpec);
             when(uriSpec.retrieve()).thenReturn(responseSpec);
             when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
             when(responseSpec.bodyToMono(UserDto.class)).thenReturn(Mono.just(new UserDto()));

--- a/services/car-service/src/main/java/com/dynamiccarsharing/car/client/UserClient.java
+++ b/services/car-service/src/main/java/com/dynamiccarsharing/car/client/UserClient.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "user-service", path = "/api/v1")
+@FeignClient(name = "user-service", path = "/api/v1", configuration = UserClientFeignConfig.class)
 public interface UserClient {
     @GetMapping("/internal/users/by-email/{email}")
     UserDto getUserByEmail(@PathVariable("email") String email);

--- a/services/car-service/src/main/java/com/dynamiccarsharing/car/client/UserClientFeignConfig.java
+++ b/services/car-service/src/main/java/com/dynamiccarsharing/car/client/UserClientFeignConfig.java
@@ -1,0 +1,22 @@
+package com.dynamiccarsharing.car.client;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.StringUtils;
+
+public class UserClientFeignConfig {
+
+    private static final String INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key";
+
+    @Bean
+    public RequestInterceptor userServiceInternalApiKeyInterceptor(
+            @Value("${USER_SERVICE_INTERNAL_API_KEY:}") String apiKey
+    ) {
+        return requestTemplate -> {
+            if (StringUtils.hasText(apiKey)) {
+                requestTemplate.header(INTERNAL_API_KEY_HEADER, apiKey);
+            }
+        };
+    }
+}

--- a/services/user-service/src/main/java/com/dynamiccarsharing/user/config/SecurityConfig.java
+++ b/services/user-service/src/main/java/com/dynamiccarsharing/user/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.dynamiccarsharing.user.config;
 
-import com.dynamiccarsharing.user.service.UserServiceImpl;
+import com.dynamiccarsharing.user.security.InternalApiKeyAuthenticationFilter;
 import com.dynamiccarsharing.util.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -26,16 +27,19 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private final InternalApiKeyAuthenticationFilter internalApiKeyAuthenticationFilter;
     private final JwtAuthenticationFilter jwtAuthFilter;
-    private final UserServiceImpl userService;
+    private final UserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req ->
-                        req.requestMatchers(
-                                "/auth/**",
+                        req.requestMatchers("/api/v1/internal/**")
+                                .hasAuthority("ROLE_INTERNAL")
+                                .requestMatchers(
+                                        "/auth/**",
                                         "/actuator/**"
                                 )
                                 .permitAll()
@@ -44,6 +48,7 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
                 .authenticationProvider(authenticationProvider())
+                .addFilterBefore(internalApiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
@@ -56,7 +61,7 @@ public class SecurityConfig {
     @Bean
     public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(userService);
+        authProvider.setUserDetailsService(userDetailsService);
         authProvider.setPasswordEncoder(passwordEncoder());
         return authProvider;
     }

--- a/services/user-service/src/main/java/com/dynamiccarsharing/user/controller/UserController.java
+++ b/services/user-service/src/main/java/com/dynamiccarsharing/user/controller/UserController.java
@@ -88,6 +88,19 @@ public class UserController {
         return ResponseEntity.ok(updatedUser);
     }
 
+    @GetMapping("/internal/users/{userId}")
+    public ResponseEntity<UserDto> getUserByIdForService(@PathVariable Long userId) throws UnknownHostException {
+        String hostname = InetAddress.getLocalHost().getHostName();
+        log.info("Internal request for user {} handled by instance: {}", userId, hostname);
+
+        return userService.findUserById(userId)
+                .map(user -> {
+                    user.setInstanceId(instanceId);
+                    return ResponseEntity.ok(user);
+                })
+                .orElse(ResponseEntity.noContent().build());
+    }
+
     @GetMapping("/internal/users/by-email/{email:.+}")
     public ResponseEntity<UserDto> getUserByEmailForService(@PathVariable String email) {
         return userService.findByEmail(email)

--- a/services/user-service/src/main/java/com/dynamiccarsharing/user/security/InternalApiKeyAuthenticationFilter.java
+++ b/services/user-service/src/main/java/com/dynamiccarsharing/user/security/InternalApiKeyAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.dynamiccarsharing.user.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.List;
+
+@Component
+public class InternalApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key";
+
+    private static final String INTERNAL_URI_PREFIX = "/api/v1/internal/";
+
+    private final String configuredInternalApiKey;
+
+    public InternalApiKeyAuthenticationFilter(
+            @Value("${application.security.internal-api-key:}") String configuredInternalApiKey
+    ) {
+        this.configuredInternalApiKey = configuredInternalApiKey;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        if (!uri.startsWith(INTERNAL_URI_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!StringUtils.hasText(configuredInternalApiKey)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Internal API is not configured");
+            return;
+        }
+
+        String provided = request.getHeader(INTERNAL_API_KEY_HEADER);
+        byte[] expected = configuredInternalApiKey.getBytes(StandardCharsets.UTF_8);
+        byte[] actual = (provided != null ? provided : "").getBytes(StandardCharsets.UTF_8);
+        if (!MessageDigest.isEqual(expected, actual)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid internal API key");
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                "internal-service",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_INTERNAL"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/services/user-service/src/main/java/com/dynamiccarsharing/user/security/InternalApiKeyStartupValidator.java
+++ b/services/user-service/src/main/java/com/dynamiccarsharing/user/security/InternalApiKeyStartupValidator.java
@@ -1,0 +1,34 @@
+package com.dynamiccarsharing.user.security;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+
+@Component
+public class InternalApiKeyStartupValidator implements ApplicationListener<ApplicationStartedEvent> {
+
+    private final Environment environment;
+
+    public InternalApiKeyStartupValidator(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationStartedEvent event) {
+        if (StringUtils.hasText(environment.getProperty("application.security.internal-api-key", ""))) {
+            return;
+        }
+        boolean testProfile = Arrays.asList(environment.getActiveProfiles()).contains("test");
+        if (testProfile) {
+            return;
+        }
+        throw new IllegalStateException(
+                "application.security.internal-api-key must be set (for example via USER_SERVICE_INTERNAL_API_KEY), "
+                        + "unless the Spring profile 'test' is active."
+        );
+    }
+}

--- a/services/user-service/src/main/resources/application.yml
+++ b/services/user-service/src/main/resources/application.yml
@@ -41,6 +41,7 @@ application:
       retry-max-attempts: 2
       retry-backoff-millis: 200
   security:
+    internal-api-key: ${USER_SERVICE_INTERNAL_API_KEY:}
     jwt:
       secret-key: NDM0YjVmNjM1MTY0NWE3NDc3Mzg3YTMzNjE1MTQxNTg0NTUxNDg0ZjU0N2IzYjRmNmE1YjdhNmE0ZDQxNjM1Mg==
       expiration: 3600000

--- a/services/user-service/src/test/java/com/dynamiccarsharing/user/controller/UserControllerTest.java
+++ b/services/user-service/src/test/java/com/dynamiccarsharing/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.dynamiccarsharing.contracts.dto.UserDto;
 import com.dynamiccarsharing.contracts.enums.UserRole;
 import com.dynamiccarsharing.contracts.enums.UserStatus;
 import com.dynamiccarsharing.user.config.SecurityConfig;
+import com.dynamiccarsharing.user.security.InternalApiKeyAuthenticationFilter;
 import com.dynamiccarsharing.user.dto.ContactInfoCreateRequestDto;
 import com.dynamiccarsharing.user.dto.ContactInfoUpdateRequestDto;
 import com.dynamiccarsharing.user.dto.UserCreateRequestDto;
@@ -27,6 +28,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -44,9 +46,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = UserController.class, properties = "eureka.instance.instance-id=test-instance-1")
-@Import({SecurityConfig.class, UserControllerTest.PassThroughJwtFilterConfig.class})
+@WebMvcTest(value = UserController.class, properties = {
+        "eureka.instance.instance-id=test-instance-1",
+        "application.security.internal-api-key=test-internal-api-key-for-integration"
+})
+@Import({SecurityConfig.class, InternalApiKeyAuthenticationFilter.class, UserControllerTest.PassThroughJwtFilterConfig.class})
+@ActiveProfiles("test")
 class UserControllerTest {
+
+    private static final String VALID_INTERNAL_API_KEY = "test-internal-api-key-for-integration";
 
     @Autowired
     MockMvc mockMvc;
@@ -155,7 +163,6 @@ class UserControllerTest {
     }
 
     @Test
-    @WithMockUser
     void getUserByEmailForService_whenUserExists_shouldReturnUser() throws Exception {
         String email = "internal@example.com";
         ContactInfoDto contactDto = new ContactInfoDto();
@@ -166,19 +173,51 @@ class UserControllerTest {
 
         when(userServiceImpl.findByEmail(email)).thenReturn(Optional.of(userDto));
 
-        mockMvc.perform(get("/api/v1/internal/users/by-email/{email}", email))
+        mockMvc.perform(get("/api/v1/internal/users/by-email/{email}", email)
+                        .header(InternalApiKeyAuthenticationFilter.INTERNAL_API_KEY_HEADER, VALID_INTERNAL_API_KEY))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.contactInfo.email").value(email));
     }
 
     @Test
-    @WithMockUser
     void getUserByEmailForService_whenUserNotExists_shouldReturnNotFound() throws Exception {
         String email = "notfound@example.com";
         when(userServiceImpl.findByEmail(email)).thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/v1/internal/users/by-email/{email}", email))
+        mockMvc.perform(get("/api/v1/internal/users/by-email/{email}", email)
+                        .header(InternalApiKeyAuthenticationFilter.INTERNAL_API_KEY_HEADER, VALID_INTERNAL_API_KEY))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getUserByEmailForService_whenApiKeyMissing_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/internal/users/by-email/{email}", "any@example.com"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getUserByEmailForService_whenApiKeyInvalid_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/internal/users/by-email/{email}", "any@example.com")
+                        .header(InternalApiKeyAuthenticationFilter.INTERNAL_API_KEY_HEADER, "wrong-key"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getUserByIdForService_whenUserExists_shouldReturnUser() throws Exception {
+        ContactInfoDto contactDto = new ContactInfoDto();
+        contactDto.setEmail("svc@example.com");
+        UserDto userDto = new UserDto();
+        userDto.setId(2L);
+        userDto.setContactInfo(contactDto);
+
+        when(userServiceImpl.findUserById(2L)).thenReturn(Optional.of(userDto));
+
+        mockMvc.perform(get("/api/v1/internal/users/{userId}", 2L)
+                        .header(InternalApiKeyAuthenticationFilter.INTERNAL_API_KEY_HEADER, VALID_INTERNAL_API_KEY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(2L))
+                .andExpect(jsonPath("$.contactInfo.email").value("svc@example.com"))
+                .andExpect(jsonPath("$.instanceId").value("test-instance-1"));
     }
 
     @Test

--- a/services/user-service/src/test/java/com/dynamiccarsharing/user/integration/InternalUserApiSecurityIntegrationTest.java
+++ b/services/user-service/src/test/java/com/dynamiccarsharing/user/integration/InternalUserApiSecurityIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.dynamiccarsharing.user.integration;
+
+import com.dynamiccarsharing.contracts.enums.UserRole;
+import com.dynamiccarsharing.contracts.enums.UserStatus;
+import com.dynamiccarsharing.user.UserApplication;
+import com.dynamiccarsharing.user.model.ContactInfo;
+import com.dynamiccarsharing.user.model.User;
+import com.dynamiccarsharing.user.repository.jpa.UserJpaRepository;
+import com.dynamiccarsharing.user.security.InternalApiKeyAuthenticationFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = UserApplication.class)
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "jpa"})
+class InternalUserApiSecurityIntegrationTest {
+
+    private static final String VALID_KEY = "test-internal-api-key-for-integration";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserJpaRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void clean() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void internalUserById_withoutApiKey_returnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/internal/users/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void internalUserById_withValidApiKey_returnsUserFromDatabase() throws Exception {
+        ContactInfo contact = ContactInfo.builder()
+                .email("internal-api-it@example.com")
+                .phoneNumber("+10000000003")
+                .firstName("Internal")
+                .lastName("It")
+                .password(passwordEncoder.encode("secret"))
+                .build();
+
+        User user = User.builder()
+                .contactInfo(contact)
+                .role(UserRole.RENTER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        Long id = userRepository.save(user).getId();
+
+        mockMvc.perform(get("/api/v1/internal/users/{userId}", id)
+                        .header(InternalApiKeyAuthenticationFilter.INTERNAL_API_KEY_HEADER, VALID_KEY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id))
+                .andExpect(jsonPath("$.contactInfo.email").value("internal-api-it@example.com"));
+    }
+}

--- a/services/user-service/src/test/resources/application-test.yml
+++ b/services/user-service/src/test/resources/application-test.yml
@@ -19,6 +19,7 @@ spring:
 
 application:
   security:
+    internal-api-key: test-internal-api-key-for-integration
     jwt:
       secret-key: NDM0YjVmNjM1MTY0NWE3NDc3Mzg3YTMzNjE1MTQxNTg0NTUxNDg0ZjU0N2IzYjRmNmE1YjdhNmE0ZDQxNjM1Mg==
       expiration: 3600000


### PR DESCRIPTION
Require X-Internal-Api-Key for /api/v1/internal/**, wire booking WebClient and car Feign client, document USER_SERVICE_INTERNAL_API_KEY for compose.

Closes #26