### PR TITLE
fix: align controller and exception tests with unified error contract

### DIFF
--- a/services/booking-service/src/test/java/com/dynamiccarsharing/booking/controller/BookingControllerTest.java
+++ b/services/booking-service/src/test/java/com/dynamiccarsharing/booking/controller/BookingControllerTest.java
@@ -65,10 +65,10 @@ class BookingControllerTest {
 
     @Test
     @WithMockUser
-    void getBookingById_whenNotExists_shouldReturnNotContent() throws Exception {
+    void getBookingById_whenNotExists_shouldReturnNotFound() throws Exception {
         when(bookingService.findById(999L)).thenReturn(Optional.empty());
         mockMvc.perform(get("/api/v1/bookings/{bookingId}", 999L))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/services/booking-service/src/test/java/com/dynamiccarsharing/booking/controller/TransactionControllerTest.java
+++ b/services/booking-service/src/test/java/com/dynamiccarsharing/booking/controller/TransactionControllerTest.java
@@ -50,11 +50,11 @@ class TransactionControllerTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void getTransactionById_whenNotExists_shouldReturnNoContent() throws Exception {
+    void getTransactionById_whenNotExists_shouldReturnNotFound() throws Exception {
         when(transactionService.findTransactionById(999L)).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/v1/admin/transactions/{id}", 999L))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/services/car-service/src/test/java/com/dynamiccarsharing/car/exception/GlobalExceptionHandlerTest.java
+++ b/services/car-service/src/test/java/com/dynamiccarsharing/car/exception/GlobalExceptionHandlerTest.java
@@ -41,7 +41,7 @@ class GlobalExceptionHandlerTest {
         FieldError fieldError = new FieldError("car", "model", "Model cannot be null");
 
         when(ex.getBindingResult()).thenReturn(bindingResult);
-        when(bindingResult.getFieldErrors()).thenReturn(List.of(fieldError));
+        when(bindingResult.getAllErrors()).thenReturn(List.of(fieldError));
 
         ProblemDetail problemDetail = exceptionHandler.handleMethodArgumentNotValidException(ex);
 
@@ -84,15 +84,14 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleAccessDenied() {
-        String errorMessage = "User is not authorized to perform this action";
-        AccessDeniedException ex = new AccessDeniedException(errorMessage);
+        AccessDeniedException ex = new AccessDeniedException("User is not authorized to perform this action");
 
         ProblemDetail problemDetail = exceptionHandler.handleAccessDenied(ex);
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), problemDetail.getStatus());
-        assertEquals("Unauthorized", problemDetail.getTitle());
-        assertEquals(errorMessage, problemDetail.getDetail());
-        assertEquals(URI.create("/errors/unauthorized"), problemDetail.getType());
+        assertEquals(HttpStatus.FORBIDDEN.value(), problemDetail.getStatus());
+        assertEquals("Forbidden", problemDetail.getTitle());
+        assertEquals("You do not have permission to perform this action.", problemDetail.getDetail());
+        assertEquals(URI.create("/errors/forbidden"), problemDetail.getType());
     }
 
     @Test

--- a/services/user-service/src/main/java/com/dynamiccarsharing/user/exception/handler/GlobalExceptionHandler.java
+++ b/services/user-service/src/main/java/com/dynamiccarsharing/user/exception/handler/GlobalExceptionHandler.java
@@ -3,10 +3,7 @@ package com.dynamiccarsharing.user.exception.handler;
 import com.dynamiccarsharing.user.exception.InvalidUserStatusException;
 import com.dynamiccarsharing.user.exception.UserNotFoundException;
 import com.dynamiccarsharing.util.web.AbstractGlobalExceptionHandler;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ProblemDetail;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,14 +12,6 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler {
-
-    public ProblemDetail handleAccessDenied(AccessDeniedException ex, HttpServletRequest req) {
-        return super.handleAccessDenied(ex);
-    }
-
-    public ProblemDetail handleNoCreds(AuthenticationCredentialsNotFoundException ex, HttpServletRequest req) {
-        return super.handleAccessDenied(ex);
-    }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ProblemDetail handleUserNotFoundException(UserNotFoundException ex) {

--- a/services/user-service/src/test/java/com/dynamiccarsharing/user/exception/GlobalExceptionHandlerTest.java
+++ b/services/user-service/src/test/java/com/dynamiccarsharing/user/exception/GlobalExceptionHandlerTest.java
@@ -3,11 +3,8 @@ package com.dynamiccarsharing.user.exception;
 import com.dynamiccarsharing.user.exception.handler.GlobalExceptionHandler;
 import com.dynamiccarsharing.util.exception.ConflictException;
 import com.dynamiccarsharing.util.exception.ResourceNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -23,46 +20,40 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
 
 class GlobalExceptionHandlerTest {
 
     private GlobalExceptionHandler exceptionHandler;
 
-    @Mock
-    private HttpServletRequest mockRequest;
-
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         exceptionHandler = new GlobalExceptionHandler();
-        when(mockRequest.getRequestURI()).thenReturn("/test-uri");
     }
 
     @Test
     void handleAccessDenied() {
         AccessDeniedException ex = new AccessDeniedException("Access Denied");
 
-        ProblemDetail problemDetail = exceptionHandler.handleAccessDenied(ex, mockRequest);
+        ProblemDetail problemDetail = exceptionHandler.handleAccessDenied(ex);
 
         assertEquals(HttpStatus.FORBIDDEN.value(), problemDetail.getStatus());
         assertEquals("Forbidden", problemDetail.getTitle());
         assertEquals("You do not have permission to perform this action.", problemDetail.getDetail());
         assertEquals(URI.create("/errors/forbidden"), problemDetail.getType());
-        assertEquals(URI.create("/test-uri"), problemDetail.getInstance());
+        assertEquals(null, problemDetail.getInstance());
     }
 
     @Test
     void handleNoCreds() {
         AuthenticationCredentialsNotFoundException ex = new AuthenticationCredentialsNotFoundException("No creds");
 
-        ProblemDetail problemDetail = exceptionHandler.handleNoCreds(ex, mockRequest);
+        ProblemDetail problemDetail = exceptionHandler.handleAccessDenied(ex);
 
         assertEquals(HttpStatus.FORBIDDEN.value(), problemDetail.getStatus());
         assertEquals("Forbidden", problemDetail.getTitle());
-        assertEquals("Authentication is required for this action.", problemDetail.getDetail());
+        assertEquals("You do not have permission to perform this action.", problemDetail.getDetail());
         assertEquals(URI.create("/errors/forbidden"), problemDetail.getType());
-        assertEquals(URI.create("/test-uri"), problemDetail.getInstance());
+        assertEquals(null, problemDetail.getInstance());
     }
 
     @Test


### PR DESCRIPTION
Update booking not-found controller expectations to 404 and adjust user/car exception handler tests and user handler wiring to remove ambiguous mappings introduced by shared ProblemDetail handling.